### PR TITLE
Add support for multiple names

### DIFF
--- a/main.go
+++ b/main.go
@@ -8,7 +8,7 @@ import (
 
 var (
 	threads            int
-	baseName           string
+	names              []string
 	wordListFile       string
 	preAndSuffixesFile string
 )
@@ -17,7 +17,7 @@ const version = "0.0.1"
 const usage = `s3enum
 
 Usage:
-  s3enum --wordlist wl.txt --suffixlist sl.txt [--threads 2] <name>
+  s3enum --wordlist wl.txt --suffixlist sl.txt [--threads 2] <name>...
   s3enum -h | --help
   s3enum --version
 
@@ -38,7 +38,7 @@ func main() {
 		os.Exit(0)
 	}
 
-	baseName = opts["<name>"].(string)
+	names = opts["<name>"].([]string)
 	preAndSuffixesFile = opts["--suffixlist"].(string)
 	wordListFile = opts["--wordlist"].(string)
 	threads, _ = opts.Int("--threads")
@@ -74,7 +74,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	producer.ProduceWordList(baseName, wordListFile)
+	producer.ProduceWordList(names, wordListFile)
 
 	// NOTE: producer closes their own channel
 	<-wordDone

--- a/producer.go
+++ b/producer.go
@@ -58,14 +58,14 @@ func (p *Producer) ProduceWordList(names []string, list string) {
 }
 
 // Produce produces candidates
-func (p *Producer) Produce(name string, word string) {
+func (p *Producer) Produce(name, word string) {
 	for _, ca := range p.PrepareCandidateBucketNames(name, word) {
 		p.channel <- ca
 	}
 }
 
 // PrepareCandidateBucketNames creates all candidate pairs
-func (p *Producer) PrepareCandidateBucketNames(name string, word string) []string {
+func (p *Producer) PrepareCandidateBucketNames(name, word string) []string {
 	result := []string{}
 
 	for _, del := range p.delimiters {

--- a/producer.go
+++ b/producer.go
@@ -33,8 +33,10 @@ func NewProducer(preAndSuffixesFile string, wordChannel chan string, quit chan b
 }
 
 // ProduceWordList produces candidate bucket names to the channel.
-func (p *Producer) ProduceWordList(basename string, list string) {
-	p.channel <- basename
+func (p *Producer) ProduceWordList(names []string, list string) {
+	for _, n := range names {
+		p.channel <- n
+	}
 
 	file, err := os.Open(list)
 	if err != nil {
@@ -47,26 +49,28 @@ func (p *Producer) ProduceWordList(basename string, list string) {
 
 	for scanner.Scan() {
 		line := scanner.Text()
-		p.Produce(basename, line)
+		for _, n := range names {
+			p.Produce(n, line)
+		}
 	}
 
 	close(p.channel)
 }
 
 // Produce produces candidates
-func (p *Producer) Produce(basename string, word string) {
-	for _, ca := range p.PrepareCandidateBucketNames(basename, word) {
+func (p *Producer) Produce(name string, word string) {
+	for _, ca := range p.PrepareCandidateBucketNames(name, word) {
 		p.channel <- ca
 	}
 }
 
 // PrepareCandidateBucketNames creates all candidate pairs
-func (p *Producer) PrepareCandidateBucketNames(basename string, word string) []string {
+func (p *Producer) PrepareCandidateBucketNames(name string, word string) []string {
 	result := []string{}
 
 	for _, del := range p.delimiters {
-		cand1 := fmt.Sprintf("%s%s%s", basename, del, word)
-		cand2 := fmt.Sprintf("%s%s%s", word, del, basename)
+		cand1 := fmt.Sprintf("%s%s%s", name, del, word)
+		cand2 := fmt.Sprintf("%s%s%s", word, del, name)
 
 		result = append(result, cand1)
 		result = append(result, cand2)


### PR DESCRIPTION
This allows `s3enum` to be run with multiple "base" names:

```
s3enum --wordlist wl.txt --suffixlist sl.txt microsoft apple google
```

https://github.com/koenrh/s3enum/issues/19